### PR TITLE
check

### DIFF
--- a/client/src/components/listing/ImageUploader.jsx
+++ b/client/src/components/listing/ImageUploader.jsx
@@ -6,7 +6,7 @@ export default function imageUploader({ images, onChange }) {
 
 	async function addImageByUrl(e) {
 		e.preventDefault();
-		const { data: filename } = await axios.post('/upload-by-url', {
+		const { data: filename } = await axios.post('/api/upload-by-url', {
 			link: imageUrl,
 		});
 		onChange((prev) => {

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -7,10 +7,10 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:4000',  // your backend
+        target: 'https://chatbot-5tek.onrender.com',  // your backend
         changeOrigin: true,
         secure: false,
-        rewrite: (path) => path.replace(/api/, ''),
+        rewrite: (path) => path.replace(/^\api/, ''),
       },
     },
   },


### PR DESCRIPTION
## Summary by Sourcery

Update client-side proxy and API calls to point to the deployed backend and properly strip the '/api' prefix

Enhancements:
- fix proxy rewrite regex to correctly remove '/api' prefix
- prefix image uploader axios call with '/api'

Build:
- change Vite dev server proxy target from localhost to the Render production URL